### PR TITLE
lang 属性を en から ja に変更する

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "start": "per-env",
     "start:production": "npm run -s serve",
     "start:development": "npm run -s dev",
-    "build": "preact build && node scripts/insert-mochinoa-aa-to-html",
-    "build:gh": "GITHUB_PAGES=homepage preact build && dot-json ./build/manifest.json start_url \"/homepage/\"",
-    "serve": "preact build && sirv build --port 8080 --cors --single",
-    "dev": "preact watch",
+    "build": "preact build --template src/template.html && node scripts/insert-mochinoa-aa-to-html",
+    "build:gh": "GITHUB_PAGES=homepage preact build --template src/template.html && dot-json ./build/manifest.json start_url \"/homepage/\"",
+    "serve": "preact build --template src/template.html && sirv build --port 8080 --cors --single",
+    "dev": "preact watch --template src/template.html",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'"
   },
   "husky": {

--- a/src/template.html
+++ b/src/template.html
@@ -1,0 +1,36 @@
+<!-- MIT License
+
+Copyright (c) 2017 Jason Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title><% preact.title %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" href="./assets/icons/apple-touch-icon.png">
+    <% preact.headEnd %>
+</head>
+<body>
+<% preact.bodyEnd %>
+</body>
+</html>

--- a/src/template.html
+++ b/src/template.html
@@ -20,7 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. -->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="utf-8">
     <title><% preact.title %></title>


### PR DESCRIPTION
望月のあちゃん、初めまして！
ホームページ見てかわいいなと思ったので、PR出します💪

## WHAT

- htmlタグのlang属性にjaを設定しました。
- 上を実現するために、テンプレートをpreact-cliから取ってきて使うようにしました。

## WHY

スマホやPCのChromeで見たときに、Google翻訳の案内が出てしまうため。

<img width="1920" alt="スクリーンショット 2020-04-07 20 07 40" src="https://user-images.githubusercontent.com/31735614/78662943-43a9ee80-790c-11ea-9fb9-51de8839a36c.png">
