### PR TITLE
feat: disable lazy loading CSS

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -19,6 +19,12 @@ export default {
             JSON.stringify(`${process.env.GITHUB_PAGES}`);
 
         config.output.publicPath = publicPath;
+
+        const indexCritters = config.plugins.findIndex(plugin => plugin.constructor && plugin.constructor.name === "Critters");
+        if (indexCritters !== -1) {
+            config.plugins.splice(indexCritters, 1);
+        }
+
         const { plugin } = helpers.getPluginsByName(config, "DefinePlugin")[0];
         Object.assign(plugin.definitions, {
             ["process.env.GITHUB_PAGES"]: ghEnv


### PR DESCRIPTION
## Proposal

ページリロード時のスタイル崩れを防ぐために、CSSの遅延読み込みを廃止する。

## Solutions

- preactにbuilt-inで入っている[Critters](https://github.com/GoogleChromeLabs/critters)を無効化する。
