### PR TITLE
feat: 予定表の埋め込み

### DIFF
--- a/src/helpers/calendar.ts
+++ b/src/helpers/calendar.ts
@@ -1,0 +1,40 @@
+export interface CalendarOptions {
+    src: string;
+    height: number;
+    showTitle: boolean;
+    showNav: boolean;
+    showPrint: boolean;
+    showTabs: boolean;
+    showCalendars: boolean;
+    showTz: boolean;
+    showDate: boolean;
+    weekStart: 1 | 2 | 3 | 4 | 5 | 6;
+    timezone: string;
+    mode: "AGENDA" | "WEEK" | "MONTH";
+}
+
+export function getCalenderURL(
+    baseURL: string,
+    parameters: CalendarOptions
+): string {
+    const n: Record<string, string> = {
+        src: parameters.src,
+        ctz: parameters.timezone,
+        height: parameters.height.toString(),
+        showTitle: parameters.showTitle ? "1" : "0",
+        showNav: parameters.showTitle ? "1" : "0",
+        showPrint: parameters.showTitle ? "1" : "0",
+        showTabs: parameters.showTitle ? "1" : "0",
+        showCalendars: parameters.showTitle ? "1" : "0",
+        showTz: parameters.showTitle ? "1" : "0",
+        showDate: parameters.showTitle ? "1" : "0",
+        wkst: parameters.weekStart.toString(),
+        mode: parameters.mode.toString()
+    };
+    return [
+        baseURL,
+        Object.keys(n)
+            .map(key => `${key}=${n[key]}`)
+            .join("&")
+    ].join("?");
+}

--- a/src/helpers/device.ts
+++ b/src/helpers/device.ts
@@ -1,0 +1,4 @@
+import { isBrowser } from "./window";
+export const isSmartphone = (): boolean =>
+    isBrowser &&
+    ["Android", "Phone"].some(v => window.navigator.userAgent.includes(v));

--- a/src/helpers/window.ts
+++ b/src/helpers/window.ts
@@ -1,0 +1,4 @@
+export const isBrowser =
+    typeof window !== "undefined" &&
+    typeof document !== "undefined" &&
+    window.document === document;

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -1,12 +1,34 @@
 import { FunctionalComponent, h } from "preact";
 import * as style from "./style.css";
 import LinkButton from "../../components/link_button";
+import { getCalenderURL } from "../../helpers/calendar";
+import { isSmartphone } from "../../helpers/device";
+import { isBrowser } from "../../helpers/window";
 
 const Home: FunctionalComponent = () => {
     const isDarkMode =
-        typeof window !== "undefined" &&
+        isBrowser &&
         window.matchMedia &&
         window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const smartphone = isSmartphone();
+    const calenderWidth = smartphone ? "300px" : "800px";
+    const calenderURL = getCalenderURL(
+        "https://calendar.google.com/calendar/b/1/embed",
+        {
+            src: "hp1cjinb4dhjh7pk3k6ln7138g@group.calendar.google.com",
+            height: 600,
+            showTitle: false,
+            showNav: false,
+            showPrint: false,
+            showTabs: false,
+            showCalendars: false,
+            showTz: false,
+            showDate: false,
+            weekStart: 1,
+            timezone: "Asia/Tokyo",
+            mode: smartphone ? "AGENDA" : "WEEK"
+        }
+    );
     return (
         <div class={style.home}>
             <head>
@@ -77,6 +99,14 @@ const Home: FunctionalComponent = () => {
                             More Videos
                         </a>
                     </p>
+                </div>
+                <div class={style.calenderBox}>
+                    <h3>予定表</h3>
+                    <iframe
+                        width={calenderWidth}
+                        height="600px"
+                        src={calenderURL}
+                    ></iframe>
                 </div>
             </div>
             <div class={style.back}>

--- a/src/routes/home/style.css
+++ b/src/routes/home/style.css
@@ -55,6 +55,24 @@
     margin: 0 auto;
 }
 
+.home .main .calender-box {
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    width: 100%;
+    max-width: 960px;
+    background: rgba(255, 255, 255, 0.6);
+    margin: 70px auto;
+    text-align: center;
+    padding: 10px;
+    border-radius: 10px;
+}
+
+.home .main .calender-box iframe {
+    max-width: 800px;
+    margin-bottom: 20px;
+}
+
 .home .back {
     position: fixed;
     width: 60%;

--- a/src/routes/home/style.css.d.ts
+++ b/src/routes/home/style.css.d.ts
@@ -4,4 +4,5 @@ export const main: string;
 export const topLogo: string;
 export const links: string;
 export const youtubeBox: string;
+export const calenderBox: string;
 export const back: string;


### PR DESCRIPTION
レイアウトの事情で PC では月または週表示、スマートフォンでは予定表表示がよさそうでした。
月 or 週については、予定表の性質 (そんなに先まで入れない) を考慮して週表示を選択しました。

PC での様子
<img width="1053" alt="スクリーンショット 2020-04-23 0 47 29" src="https://user-images.githubusercontent.com/603523/80005335-64726680-84fe-11ea-9901-58cf89f56c82.png">

スマートフォンでの様子
<img width="487" alt="スクリーンショット 2020-04-23 0 48 26" src="https://user-images.githubusercontent.com/603523/80005323-60dedf80-84fe-11ea-934d-fca004e4731d.png">
